### PR TITLE
Pluralization support for words.

### DIFF
--- a/src/spellck/lib.rs
+++ b/src/spellck/lib.rs
@@ -1,5 +1,5 @@
 #![crate_name = "spellck"]
-#![feature(phase, plugin_registrar)]
+#![feature(phase, plugin_registrar, slicing_syntax)]
 
 
 extern crate syntax;

--- a/src/spellck/visitor.rs
+++ b/src/spellck/visitor.rs
@@ -77,7 +77,8 @@ impl<'a> SpellingVisitor<'a> {
     fn raw_word_is_correct(&mut self, w: &str) -> bool {
         self.words.contains_equiv(&w) ||
             !w.chars().all(|c| c.is_alphabetic()) ||
-            self.words.contains_equiv(&w.to_ascii_lower())
+            self.words.contains_equiv(&w.to_ascii_lower()) ||
+            (w.ends_with("s") && self.words.contains_equiv(&w.to_ascii_lower()[.. w.len() - 1]))
     }
 
     /// Check a word for correctness, including splitting `foo_bar`


### PR DESCRIPTION
This checks if the word being checked ends with an "s" and if so sees if the version without the final "s" is a valid word.  This satisfies the one requirement on #5 :

As of this change Ducks is allowed as Duck on /usr/share/dict/words

What else is needed to make this a worthwhile pull request? 
