### PR TITLE
spellck_extra_words attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ line. `src/stdlib.txt` is the words/abbreviations/sequences of letters
 from the Rust standard library that are correct, but are not in my
 `/usr/share/dict/words`.
 
-Known to work with Rust commit b87619e27 2014-11-02 23:27:10.
+Known to work with Rust commit e09d98603 2014-11-18 23:51:43.
 
 
 ## Installation
@@ -81,6 +81,15 @@ spellck_example.rs:6 /// Bad dok coment
 spellck_example.rs:7:1: 7:22 warning: misspelled word: mispelled, #[warn(misspellings)] on by default
 spellck_example.rs:7 pub fn mispelled() {}
                      ^~~~~~~~~~~~~~~~~~~~~
+```
+
+Words can also be added to the list of valid words using an attribute containing a string of space separated words in the crate root like so:
+
+```rust
+// lib.rs -- the crate root
+#![spellck_extra_words="these are not in word list but are now"]
+
+#[phase(plugin)] extern crate spellck;
 ```
 
 At the moment, the explicit `extern crate` is required as there is no

--- a/src/bin/spellck_standalone.rs
+++ b/src/bin/spellck_standalone.rs
@@ -8,6 +8,7 @@ extern crate getopts;
 extern crate arena;
 extern crate syntax;
 extern crate rustc;
+extern crate rustc_trans;
 
 extern crate spellck;
 
@@ -16,8 +17,9 @@ use std::collections::{HashSet, BinaryHeap};
 use arena::TypedArena;
 use syntax::{ast, ast_map};
 use syntax::codemap::{Span, BytePos};
-use rustc::driver::{driver, session, config};
 use rustc::middle::privacy;
+use rustc::session::{mod, config};
+use rustc_trans::driver::driver;
 
 use spellck::visitor::SpellingVisitor;
 
@@ -26,7 +28,7 @@ static LIBDIR: &'static str = "/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/l
 
 fn main() {
     let args = os::args();
-    let opts = [getopts::optmulti("d", "dict",
+    let opts = &[getopts::optmulti("d", "dict",
                                   "dictionary file (a list of words, one per line)", "PATH"),
                 getopts::optflag("n", "no-def-dict", "don't use the default dictionary"),
                 getopts::optflag("h", "help", "show this help message")];
@@ -122,7 +124,7 @@ fn main() {
     }
 }
 
-/// Load each line of the file `p` into the given `Extendable` object.
+/// Load each line of the file `p` into the given `Extend` object.
 fn read_lines_into<E: Extend<String>>
                   (p: &Path, e: &mut E) -> bool {
     match io::File::open(p) {
@@ -149,7 +151,7 @@ fn get_ast<T>(path: Path,
               f: |session::Session, &ast::Crate,
                   privacy::ExportedItems, privacy::PublicItems| -> T) -> T {
     use syntax::diagnostic;
-    use rustc::back::link;
+    use rustc_trans::back::link;
 
     // cargo culted from rustdoc_ng :(
     let input = driver::FileInput(path);

--- a/src/spellck/lib.rs
+++ b/src/spellck/lib.rs
@@ -1,5 +1,5 @@
 #![crate_name = "spellck"]
-#![feature(phase, plugin_registrar)]
+#![feature(phase, plugin_registrar, if_let)]
 
 
 extern crate syntax;

--- a/src/spellck/visitor.rs
+++ b/src/spellck/visitor.rs
@@ -77,17 +77,17 @@ impl<'a> SpellingVisitor<'a> {
     /// splitting it at all. Any word that isn't entirely alphabetic
     /// is automatically considered a proper word.
     fn raw_word_is_correct(&mut self, w: &str) -> bool {
-        self.words.contains_equiv(w.as_slice()) ||
+        self.words.contains(w.as_slice()) ||
             !w.chars().all(|c| c.is_alphabetic()) || {
                 let lower = w.to_ascii_lower();
-                self.words.contains_equiv(lower.as_slice()) ||
+                self.words.contains(lower.as_slice()) ||
                 self.stemmed_word_is_correct(lower.as_slice())
             }
     }
 
     fn stemmed_word_is_correct(&self, w: &str) -> bool {
         stem::get(w).ok().map_or(false,
-            |s| self.words.contains_equiv(s.as_slice()))
+            |s| self.words.contains(s.as_slice()))
     }
 
     /// Check a word for correctness, including splitting `foo_bar`


### PR DESCRIPTION
This has the spellck lint recognize the attribute "spellck_extra_words" so that extra words can be added from the crate root. usage is like so:

``` rust
//lib.rs
#![spellck_extra_words="these are not in word list but are now"]
```

thank you for your time :)

closes #8 
